### PR TITLE
[legacy] feat: show migration screen and allow project exporting

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,6 +75,12 @@ export default [
         BUILDVAR__VERSION: JSON.stringify(process.env.npm_package_version),
         BUILDVAR__BUILD_ENV: JSON.stringify(ENV),
         BUILDVAR__BRANCH: JSON.stringify(process.env.BRANCH),
+        BUILDVAR__NEW_APP_INSTALL_URL: JSON.stringify(
+          process.env.NEW_APP_INSTALL_URL || "https://app.design-awareness.com/"
+        ),
+        BUILDVAR__NEW_APP_NAME: JSON.stringify(
+          process.env.NEW_APP_NAME || "Design Signatures"
+        ),
         preventAssignment: true,
       }),
       commonjs(),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,28 +1,30 @@
 <script lang="ts">
-  import AllProjects from "./routes/AllProjects.svelte";
+  import Router from "svelte-spa-router/Router.svelte";
+  import { createPresets } from "./data/activitySetPresets";
+  import { awaitObjectUpgradeIfNeeded } from "./data/upgradeObjects";
   import AppDo from "./routes/about/AppDo.svelte";
   import Atmans from "./routes/about/Atmans.svelte";
+  import AllProjects from "./routes/AllProjects.svelte";
   import ComponentLibrary from "./routes/dev/ComponentLibrary.svelte";
   import DBEditor from "./routes/dev/DBEditor.svelte";
   import DevTools from "./routes/dev/DevTools.svelte";
   import Home from "./routes/Home.svelte";
+  import Migrate from "./routes/Migrate.svelte";
   import NewProject from "./routes/NewProject.svelte";
   import NotFound from "./routes/NotFound.svelte";
   import ProjectDetail from "./routes/ProjectDetail.svelte";
   import ProjectExport from "./routes/ProjectExport.svelte";
   import ProjectTracking from "./routes/ProjectTracking.svelte";
   import RedirectAddPath from "./routes/RedirectAddPath.svelte";
-  import Router from "svelte-spa-router/Router.svelte";
   import Settings from "./routes/Settings.svelte";
   import Update from "./routes/Update.svelte";
-  import { createPresets } from "./data/activitySetPresets";
-  import { awaitObjectUpgradeIfNeeded } from "./data/upgradeObjects";
 
   awaitObjectUpgradeIfNeeded();
   createPresets(); // noop, but keeps the linter happy :)
 
   const routes: object = {
-    "/": Home, // Home
+    "/": Migrate,
+    "/home": Home, // Home
 
     "/projects/": AllProjects, // Projects
     // "/projects/new/": NewProject, // New project

--- a/src/components/PageSeparator.svelte
+++ b/src/components/PageSeparator.svelte
@@ -1,0 +1,11 @@
+<hr />
+
+<style lang="scss">
+  @import "src/styles/tokens";
+
+  hr {
+    margin: $block-vertical-spacing (-$content-frame-pad);
+    border: $page-separator-size solid $text-ghost-color;
+    border-bottom-width: 0;
+  }
+</style>

--- a/src/components/ProjectExportSlat.svelte
+++ b/src/components/ProjectExportSlat.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { Project } from "../data/schema";
+  import { serialize } from "../data/serialize";
+  import download from "../util/download";
+
+  export let project: Project;
+
+  function exportProject() {
+    download(
+      `${safeName(project.name)}.json`,
+      "application/json",
+      serialize(project)
+    );
+  }
+  function safeName(name: string) {
+    return name.trim().replace(/[\W\:\/\\]+/g, "-");
+  }
+</script>
+
+<div class="slat">
+  <p>{project.name}</p>
+  <button on:click={exportProject}>Export</button>
+</div>
+
+<style lang="scss">
+  @import "src/styles/tokens";
+  @import "src/styles/type";
+
+  .slat {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    margin: 1.5rem 0;
+  }
+  p {
+    flex-grow: 1;
+    margin: 0;
+  }
+  button {
+    appearance: none;
+    -webkit-appearance: none;
+    border: 0;
+    background: transparent;
+    @include type-style($type-token);
+    color: $link-color;
+  }
+</style>

--- a/src/data/buildData.ts
+++ b/src/data/buildData.ts
@@ -6,3 +6,8 @@ export const VERSION: string = BUILDVAR__VERSION;
 export const BUILD_ENV: "dev" | "stage" | "prod" = BUILDVAR__BUILD_ENV;
 //@ts-ignore
 export const BRANCH: string = BUILDVAR__BRANCH;
+
+// @ts-ignore
+export const NEW_APP_INSTALL_URL: string = BUILDVAR__NEW_APP_INSTALL_URL;
+// @ts-ignore
+export const NEW_APP_NAME: string = BUILDVAR__NEW_APP_NAME;

--- a/src/data/serialize.ts
+++ b/src/data/serialize.ts
@@ -1,0 +1,85 @@
+import { VERSION } from "./buildData";
+import type { ActivitySet, Note, Project, Session } from "./schema";
+
+export function serialize(project: Project) {
+  return JSON.stringify(wrap(serializeProject(project)));
+}
+
+function serializeProject(project: Project) {
+  let {
+    active,
+    activitySet,
+    created,
+    description,
+    id,
+    lastModified,
+    name,
+    notes,
+    sessions,
+  } = project;
+  return {
+    active,
+    created,
+    description,
+    designModel: serializeActivitySet(activitySet),
+    id,
+    modified: lastModified,
+    name,
+    notes: notes.map(serializeNote),
+    sessions: sessions.map(serializeSession),
+  };
+}
+
+function serializeActivitySet(activitySet: ActivitySet) {
+  let {
+    activityCodes,
+    activityDescriptions,
+    activityNames,
+    colors,
+    description,
+    id,
+    name,
+  } = activitySet;
+  return {
+    activities: activityCodes.map((code, i) => ({
+      code,
+      color: colors[i],
+      description: activityDescriptions[i],
+      name: activityNames[i],
+    })),
+    description: description ? { description } : null,
+    id: "@@legacy/" + id,
+    name,
+  };
+}
+
+function serializeNote(note: Note) {
+  let { contents, created, id } = note;
+  return {
+    content: contents,
+    created,
+    id,
+  };
+}
+
+function serializeSession(session: Session) {
+  let { data, duration, id, startTime } = session;
+  return {
+    data,
+    duration,
+    id,
+    start: startTime,
+  };
+}
+
+function wrap(data: any) {
+  return {
+    $format: "design-awareness",
+    version: "1.0.0",
+    type: "RealtimeProject",
+    data,
+    meta: {
+      encoder: "design-awareness-app/legacy@" + VERSION,
+    },
+  };
+}

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -14,6 +14,11 @@
   <PageHeader />
 
   <ContentFrame>
+    <Header>New version available</Header>
+    <p>
+      <Link href="/">Install now -&gt;</Link>
+    </p>
+
     <Header>Recent projects</Header>
 
     <HorizontalScrollArea>

--- a/src/routes/Migrate.svelte
+++ b/src/routes/Migrate.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import ContentFrame from "../components/layout/ContentFrame.svelte";
+  import Header from "../components/type/Header.svelte";
+  import PageSeparator from "../components/PageSeparator.svelte";
+  import { NEW_APP_INSTALL_URL, NEW_APP_NAME } from "../data/buildData";
+  import { getAll, getProject } from "../data/database";
+  import ProjectExportSlat from "../components/ProjectExportSlat.svelte";
+  import Link from "../components/Link.svelte";
+</script>
+
+<main class="migrate">
+  <ContentFrame>
+    <Header>App Migration</Header>
+    <p>
+      Thank you for helping us test our app! The full version is now available
+      and will need to be installed separately. We'll help you migrate your
+      projects so you don't lose anything. Feel free to reach out if you're
+      having trouble migrating by <a
+        href="https://github.com/design-awareness/design-awareness-app/issues"
+        target="_blank">opening an issue in our github repository</a
+      >.
+    </p>
+    <p>
+      <Link href="/home">Keep using this app -&gt;</Link>
+    </p>
+    <PageSeparator />
+    <Header>Download Your Projects</Header>
+    <p>
+      If you want to keep any projects from this app, export them now so you can
+      import them into the new app.
+    </p>
+    <p class="small">
+      After clicking Export, you may need to choose "Save" or "Save to files" to
+      save your project on your device.
+    </p>
+    {#await getAll("Project")}
+      Loading projects…
+    {:then projects}
+      {#each projects as id}
+        {#await getProject(id) then project}
+          <ProjectExportSlat {project} />
+        {/await}
+      {/each}
+    {/await}
+    <PageSeparator />
+    <Header>Install the New App</Header>
+    <p>
+      Install the new app, <strong>{NEW_APP_NAME}</strong>, by clicking this
+      link and following the instructions:
+    </p>
+    <p>
+      <a href={NEW_APP_INSTALL_URL} target="_blank">Install {NEW_APP_NAME}</a>
+    </p>
+    <PageSeparator />
+    <Header>Import your Projects</Header>
+    <p>
+      In the new app, click the settings cog at the top right, then choose
+      <em>Import a project</em>. Select one of the projects you exported in the
+      earlier step, click import, and repeat for each project you want to
+      import.
+    </p>
+    <PageSeparator />
+    <Header>Delete This App</Header>
+    <p>
+      Once all your projects are imported into the new app, you're ready to
+      delete this one! Delete the app in the usual way for your device (usually
+      by long-pressing on the app icon).
+    </p>
+    <p>
+      Make sure you're deleting this app (<strong>Design Awareness</strong>) and
+      not the new one you just installed (<strong>{NEW_APP_NAME}</strong>).
+    </p>
+  </ContentFrame>
+</main>
+
+<style lang="scss">
+  @import "src/styles/tokens";
+  @import "src/styles/type";
+  .migrate {
+    background-color: $background-color;
+    min-height: 100%;
+    padding-top: 2rem;
+  }
+  .small {
+    @include type-style($type-detail);
+    color: $text-secondary-color;
+  }
+  a {
+    color: $link-color;
+  }
+</style>

--- a/src/routes/ProjectDetail.svelte
+++ b/src/routes/ProjectDetail.svelte
@@ -20,7 +20,7 @@
   import compareIcon from "@iconify-icons/ic/baseline-compare-arrows";
   import archiveIcon from "@iconify-icons/ic/baseline-archive";
   import unarchiveIcon from "@iconify-icons/ic/baseline-unarchive";
-  import exportIcon from "@iconify-icons/ic/baseline-share";
+  // import exportIcon from "@iconify-icons/ic/baseline-share";
   import deleteIcon from "@iconify-icons/ic/baseline-delete";
   import Modal from "../components/Modal.svelte";
   import InputField from "../components/InputField.svelte";
@@ -60,11 +60,11 @@
   const menuDescriptor = (): PopupMenuDescriptor => [
     { label: "Edit", icon: editIcon, action: () => (editProjectOpen = true) },
     { label: "Compare", icon: compareIcon, action: () => (otherOpen = true) },
-    {
-      label: "Export",
-      icon: exportIcon,
-      action: () => push(`/projects/${params.id}/export`),
-    },
+    // {
+    //   label: "Export",
+    //   icon: exportIcon,
+    //   action: () => push(`/projects/${params.id}/export`),
+    // },
     { separator: true },
     {
       label: project.active ? "Archive" : "Unarchive",

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -44,6 +44,7 @@ $neutral-90: #000000;
       timeline-gridline: $neutral-20,
       toggle-switch-neutral: $neutral-50,
       accent-danger: #b71c1c,
+      text-link: #2060b4,
     )
   );
 }
@@ -79,6 +80,7 @@ $neutral-90: #000000;
       timeline-gridline: $neutral-20,
       toggle-switch-neutral: $neutral-20,
       accent-danger: #e53c3c,
+      text-link: #7aaae9,
     )
   );
 }

--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -6,6 +6,8 @@ $text-secondary-color: getvar(text-secondary);
 $text-ghost-color: getvar(text-ghost);
 $text-opposing-color: getvar(text-opposing);
 
+$link-color: getvar(text-link);
+
 $accent-danger-color: getvar(accent-danger);
 
 $loading-placeholder-color: getvar(loading-placeholder);

--- a/src/styles/tokens.scss
+++ b/src/styles/tokens.scss
@@ -15,6 +15,9 @@ $block-vertical-spacing: 1.5rem;
 // CONTENT FRAME
 $content-frame-pad: 1rem;
 
+// PAGE SEPARATOR
+$page-separator-size: 1px;
+
 // BUTTON
 $button-border-color: getvar(button-border);
 $button-background-color: getvar(button-background);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compileOnSave": true,
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "target": "es2019"
   },
-
   "include": ["src/**/*", "./global.d.ts"],
   "exclude": ["node_modules/*", "__sapper__/*", "public/*"]
 }


### PR DESCRIPTION
This commit adds a screen that explains the migration process and allows users to export their projects in a format that can be imported by the new app. We'll deploy this to the old app URL once the new app is officially "launched" :^)