### PR TITLE
rollup: correctly check PULL_REQUEST variable

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,11 @@ import css from "rollup-plugin-css-only";
 
 const production = !process.env.ROLLUP_WATCH;
 
-const ENV = !production ? "dev" : process.env.PULL_REQUEST ? "preview" : "prod";
+const ENV = !production
+  ? "dev"
+  : process.env.PULL_REQUEST === "true"
+  ? "preview"
+  : "prod";
 
 function serve() {
   let server;


### PR DESCRIPTION
Netlify sets this to "true" or "false", so a truthy check will always return true, which is what we were doing before. Now, production deploys won't say "Deploy Preview" :^)