### PR TITLE
Builder+import+ProjectTracking: uppercase code before saving

### DIFF
--- a/src/components/DesignModel/Builder.svelte
+++ b/src/components/DesignModel/Builder.svelte
@@ -86,7 +86,7 @@
     as.name = name;
     as.description = null;
     as.activities = activities.map(({ code, color, description, name }) => ({
-      code,
+      code: code.toUpperCase(),
       color,
       description,
       name,

--- a/src/data/import.ts
+++ b/src/data/import.ts
@@ -758,7 +758,7 @@ export async function importDesignModel(
       let existingActivities = model.activities;
       model.activities = data.activities.map(
         ({ code, color, description, name }, i) => ({
-          code,
+          code: code.toUpperCase(),
           color,
           description: description ?? existingActivities[i]?.description ?? "",
           name,

--- a/src/routes/ProjectTracking.svelte
+++ b/src/routes/ProjectTracking.svelte
@@ -187,7 +187,7 @@
         const i = selectedActivity.index;
         let { code, color, description, name } = selectedActivityTemp;
         let newActivity = {
-          code,
+          code: code.toUpperCase(),
           color,
           description,
           name,


### PR DESCRIPTION
In all cases where an activity code is saved, ensure that it is
converted to uppercase.