### PR TITLE
webmanifest: rename Design Awareness -> Design Signatures

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "short_name": "Design Awareness",
-  "name": "Design Awareness",
+  "short_name": "Design Signatures",
+  "name": "Design Signatures",
   "description": "Track your design process",
   "start_url": "/",
   "scope": "/",


### PR DESCRIPTION
Changing the name here will use the name "Design Signatures" by default when installing the PWA (on iOS, "Add to home screen")