### PR TITLE
Settings+config: add a11y options for pinch zoom and text scaling

### DIFF
--- a/src/data/config.ts
+++ b/src/data/config.ts
@@ -44,6 +44,21 @@ const CONFIG = {
   setDevSuppressBeforeUnload(v: boolean) {
     return setConfig("dev__suppress_before_unload", v);
   },
+
+  getTextScalingFactor(): Promise<number> {
+    return getConfig<number>("text_scaling_factor", 0);
+  },
+  setTextScalingFactor(v: number) {
+    return setConfig("text_scaling_factor", v);
+  },
+
+  getEnablePinchToZoom(): Promise<boolean> {
+    return getConfig<boolean>("enable_pinch_to_zoom", false);
+  },
+  setEnablePinchToZoom(v: boolean) {
+    console.log("writing", v);
+    return setConfig("enable_pinch_to_zoom", v);
+  },
 };
 
 export default CONFIG;

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -6,6 +6,8 @@
   import { replace } from "svelte-spa-router/Router.svelte";
   import BackButton from "../components/BackButton.svelte";
   import Button from "../components/Button.svelte";
+  import ButtonGroup from "../components/ButtonGroup.svelte";
+  import Checkbox from "../components/Checkbox.svelte";
   import InvisibleButton from "../components/InvisibleButton.svelte";
   import ContentFrame from "../components/layout/ContentFrame.svelte";
   import Link from "../components/Link.svelte";
@@ -28,6 +30,7 @@
   } from "../data/database";
   import type { DesignModel } from "../data/schema";
   import { WELL_KNOWN_ENTITY_PREFIX } from "../data/schema";
+  import { pinchToZoomEnabled, textScalingFactor } from "../util/scaling";
 
   async function resetWellKnownModels() {
     if (confirm("Are you sure? Built-in design models will be recreated.")) {
@@ -126,6 +129,44 @@
         Reset built-in design models
       </Button>
     </p>
+
+    <SectionHeader>Accessibility</SectionHeader>
+    <p>
+      <Checkbox
+        bind:checked={$pinchToZoomEnabled}
+        label="Pinch to zoom"
+        helptext="Depending on your device and browser settings, this option might be ignored. You may need to restart the app for changes to take effect."
+      />
+    </p>
+
+    <div>
+      <p>
+        Font scaling: {$textScalingFactor === 0
+          ? "default"
+          : $textScalingFactor > 0
+          ? `+${$textScalingFactor}`
+          : $textScalingFactor}
+      </p>
+      <ButtonGroup fill>
+        <Button
+          inlabel
+          disabled={$textScalingFactor === -5}
+          on:click={() => $textScalingFactor--}
+        >
+          Smaller
+        </Button>
+        <Button inlabel on:click={() => ($textScalingFactor = 0)}
+          >Default</Button
+        >
+        <Button
+          inlabel
+          disabled={$textScalingFactor === 5}
+          on:click={() => $textScalingFactor++}
+        >
+          Larger
+        </Button>
+      </ButtonGroup>
+    </div>
 
     {#if BUILD_ENV === "dev" || tapCount > 4}
       <SectionHeader>Developer</SectionHeader>

--- a/src/util/scaling.ts
+++ b/src/util/scaling.ts
@@ -1,0 +1,46 @@
+import { writable } from "svelte/store";
+import CONFIG from "../data/config";
+
+function setViewportContent(value: string) {
+  const viewport = document.querySelector("meta[name=viewport]");
+  if (viewport) {
+    viewport.setAttribute("content", value);
+  }
+}
+
+export function setNotZoomable() {
+  setViewportContent("width=device-width,initial-scale=1.0,maximum-scale=1.0");
+}
+
+export function setZoomable() {
+  setViewportContent("width=device-width,initial-scale=1.0");
+}
+
+export const pinchToZoomEnabled = writable<boolean>(true);
+let lastPinchToZoomValue = true;
+pinchToZoomEnabled.subscribe((newValue) => {
+  if (newValue) {
+    setZoomable();
+  } else {
+    setNotZoomable();
+  }
+  if (lastPinchToZoomValue !== newValue) {
+    CONFIG.setEnablePinchToZoom(newValue);
+    lastPinchToZoomValue = newValue;
+  }
+});
+(async function () {
+  const enabled = await CONFIG.getEnablePinchToZoom();
+  pinchToZoomEnabled.set(enabled);
+})();
+
+export const textScalingFactor = writable<number>(0);
+(async function () {
+  const factor = await CONFIG.getTextScalingFactor();
+  textScalingFactor.set(factor);
+  textScalingFactor.subscribe((value) => {
+    const scaleFactor = 100 * Math.pow(1.05, value);
+    document.documentElement.style.fontSize = `${scaleFactor}%`;
+    CONFIG.setTextScalingFactor(value);
+  });
+})();


### PR DESCRIPTION
Adds accessibility section to the settings page with options to enable pinch-to-zoom and font scaling levels.

Disabling pinch to zoom by default solves the problem with zooming into input fields that sometimes happens on iOS, but making this an option should leave a11y considerations available.