### PR TITLE
Package update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "design-signatures-app",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "design-signatures-app",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@iconify/icons-ic": "^1.1.11",
@@ -1043,9 +1043,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -2634,9 +2634,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "design-awareness-www",
+  "name": "design-signatures-app",
   "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "design-awareness-www",
+      "name": "design-signatures-app",
       "version": "0.3.1",
       "license": "BSD-3-Clause",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-signatures-app",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "design-awareness-www",
+  "name": "design-signatures-app",
   "version": "0.3.1",
   "scripts": {
     "build": "rollup -c",
@@ -45,13 +45,13 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/design-awareness/design-awareness-app.git"
+    "url": "git+https://github.com/design-awareness/design-signatures-app.git"
   },
   "contributors": [
     "Jordan Yoon-Buck <jordan@yoonbuck.com> (https://github.com/yoonbuck)"
   ],
   "bugs": {
-    "url": "https://github.com/design-awareness/design-awareness-app/issues"
+    "url": "https://github.com/design-awareness/design-signatures-app/issues"
   },
-  "homepage": "https://github.com/design-awareness/design-awareness-app#readme"
+  "homepage": "https://github.com/design-awareness/design-signatures-app#readme"
 }

--- a/src/data/database.ts
+++ b/src/data/database.ts
@@ -502,7 +502,7 @@ function createClientObject(
           type: store,
           data: entryData,
           meta: {
-            encoder: "design-awareness-app@" + VERSION,
+            encoder: "design-signatures-app@" + VERSION,
           },
         },
         null,


### PR DESCRIPTION
- update path-parse dependency to fix audit (those redos vulns… 🙄 )
- `design-awareness-www` -> `design-signatures-app` in npm package
- update github links to new repo url
- `design-awareness-app` -> `design-signatures-app` in entity serialization (export) metadata