### PR TITLE
Hotfix: DevTools crash from readable store misuse

### DIFF
--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -169,17 +169,17 @@
       </ButtonGroup>
     </div>
 
+    <SectionHeader>Onboarding</SectionHeader>
+    <p>
+      <Button small on:click={openOnboarding}>Replay onboarding</Button>
+    </p>
+
     {#if BUILD_ENV === "dev" || tapCount > 4}
       <SectionHeader>Developer</SectionHeader>
       <p>
         <Link href="/dev/">Developer tools</Link>
       </p>
     {/if}
-
-    <SectionHeader>Onboarding</SectionHeader>
-    <p>
-      <Button small on:click={openOnboarding}>Replay onboarding</Button>
-    </p>
 
     <SectionHeader>About app</SectionHeader>
     <p class="small">

--- a/src/routes/dev/DevTools.svelte
+++ b/src/routes/dev/DevTools.svelte
@@ -174,7 +174,7 @@
   <Header>Device Properties</Header>
   <p>Color scheme: {$colorScheme}</p>
   <p>PWA status: {$isInstalled ? "installed" : "not installed"}</p>
-  <p>Has installation prompt: {canInstall()}</p>
+  <p>Has installation prompt: {$canInstall}</p>
 
   <Header>Danger Zone</Header>
   <p>


### PR DESCRIPTION
`canInstall` was changed to a readable store (from a normal function) but was still being called like one in DevTools. Not sure why TypeScript didn't throw a fit about this, but it's fixed now.

While I was in there, fixed the ordering of the secret DevTools link and Onboarding section in the main Settings screen.

There's probably some tweaks we should make to the production build so it will fail if this kind of error occurs?