### PR TITLE
ProjectExport+dotTimeline: show notes in async project export

### DIFF
--- a/src/routes/ProjectExport.svelte
+++ b/src/routes/ProjectExport.svelte
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2021, Design Awareness Contributors.
+  Copyright (c) 2021-2023, Design Awareness Contributors.
   SPDX-License-Identifier: BSD-3-Clause
 -->
 <script lang="ts">
@@ -145,9 +145,8 @@
 
           <RichLabel label="Features" />
           <Checkbox bind:checked={showTime} label="Show dates" />
-          <p class="small">Additional export options will be available soon!</p>
-          <Checkbox checked={false} disabled label="Show notes" />
-          <Checkbox checked={true} disabled label="Skip days without entries" />
+          <Checkbox bind:checked={showNotes} label="Show notes" />
+          <!-- <Checkbox checked={true} disabled label="Skip days without entries" /> -->
 
           <RichLabel label="Preview" />
 
@@ -158,7 +157,7 @@
                 project: projectInfo[1],
                 dpi: imageScale,
                 showDates: showTime,
-                // showNotes,
+                showNotes,
                 // hideEmptyDays
               }}
             />
@@ -197,9 +196,5 @@
     background: $alt-background-color;
     @include type-style($type-caption);
     padding: 0.75rem;
-  }
-
-  .small {
-    @include type-style($type-detail);
   }
 </style>

--- a/src/util/dotTimeline.ts
+++ b/src/util/dotTimeline.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Design Awareness Contributors.
+ * Copyright (c) 2021-2023, Design Awareness Contributors.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
@@ -13,6 +13,7 @@ export let project: AsyncProject;
 
 interface AsyncEntryLike {
   data: readonly AsyncActivityData[];
+  note?: string;
   period: Date;
 }
 
@@ -51,6 +52,7 @@ const TAU = 2 * Math.PI;
 
 /** Activity label area width */
 const ACTIVITY_LABEL_AREA_WIDTH = 52;
+const LABEL_PADDING = 6;
 
 const DOT_SIZE = 20;
 const CELL_PADDING = 2;
@@ -189,18 +191,27 @@ export default function dotTimeline(
     );
     ctx.translate(PAD_EDGE, PAD_EDGE);
 
+    function drawNoteTriangle(x: number, y: number) {
+      ctx.fillStyle = theme.noteColor;
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(x - 6, y);
+      ctx.lineTo(x, y + 6);
+      ctx.fill();
+    }
+
     // draws activity labels
     {
       let y = yTop + ENTRY_DIVIDER_OVERHANG;
       ctx.textBaseline = "middle";
-      ctx.textAlign = "center";
+      ctx.textAlign = "right";
 
       for (let activity of activities) {
         ctx.fillStyle = "#" + activity.color[colorSchemeIdx];
         ctx.font = ACTIVITY_LABEL_FONT;
         ctx.fillText(
           activity.code,
-          ACTIVITY_LABEL_AREA_WIDTH / 2,
+          ACTIVITY_LABEL_AREA_WIDTH - LABEL_PADDING,
           y + DOT_SIZE + CELL_PADDING
         );
 
@@ -240,6 +251,9 @@ export default function dotTimeline(
               DASH_HEIGHT
             );
           }
+          if (showNotes && entry.data[activity].note) {
+            drawNoteTriangle(x + CELL_SIZE, y);
+          }
           y += FULL_ROW_HEIGHT;
         }
         x += FULL_ENTRY_WIDTH;
@@ -275,6 +289,9 @@ export default function dotTimeline(
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.fillText(entries[i].period.getUTCDate().toString(), x, y);
+        if (showNotes && entries[i].note) {
+          drawNoteTriangle(x + DOT_SIZE + CELL_PADDING, MONTH_BAR_HEIGHT);
+        }
         x += FULL_ENTRY_WIDTH;
       }
     }


### PR DESCRIPTION
This change enables the "Show notes" checkbox and feature on the async project export screen and hides the skip missing days checkbox and label.

Notes are shown as a small yellow triangle in the upper right corner of the area a note applies to (the date, if a note is on an entry, and the dot if there is a note on a particular measurement).

N.B. Notes on dates are not shown if "Show dates" is unchecked.