### PR TITLE
DevTools: Avoid calling onDestroy after initialization

### DIFF
--- a/src/routes/ProjectExport.svelte
+++ b/src/routes/ProjectExport.svelte
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2021, Design Awareness Contributors.
+  Copyright (c) 2021-2023, Design Awareness Contributors.
   SPDX-License-Identifier: BSD-3-Clause
 -->
 <script lang="ts">

--- a/src/routes/dev/DevTools.svelte
+++ b/src/routes/dev/DevTools.svelte
@@ -3,10 +3,6 @@
   SPDX-License-Identifier: BSD-3-Clause
 -->
 <script lang="ts">
-  import { onDestroy } from "svelte";
-
-  import { writable } from "svelte/store";
-
   import BackButton from "../../components/BackButton.svelte";
   import Checkbox from "../../components/Checkbox.svelte";
   import ContentFrame from "../../components/layout/ContentFrame.svelte";
@@ -28,23 +24,13 @@
   import { canInstall, isInstalled } from "../../util/pwa";
 
   let reloadSuppressed = false;
+  let alwaysShowOnboarding = false;
+  let showCanvasTimelineOnProjectPage = false;
   (async function () {
     reloadSuppressed = await CONFIG.getDevSuppressBeforeUnload();
-  })();
-  let alwaysShowOnboarding = false;
-  (async function () {
     alwaysShowOnboarding = await CONFIG.getDevAlwaysShowOnboarding();
-  })();
-
-  export const showCanvasTimelineOnProjectPage = writable<boolean>(false);
-  (async function () {
-    const initialValue = await CONFIG.getDevShowCanvasTimelineOnProjectPage();
-    showCanvasTimelineOnProjectPage.set(initialValue);
-    onDestroy(
-      showCanvasTimelineOnProjectPage.subscribe(
-        CONFIG.setDevShowCanvasTimelineOnProjectPage
-      )
-    );
+    showCanvasTimelineOnProjectPage =
+      await CONFIG.getDevShowCanvasTimelineOnProjectPage();
   })();
 
   async function deleteAll() {
@@ -155,10 +141,15 @@
   </p>
 
   <p>
-    <Checkbox
-      bind:checked={$showCanvasTimelineOnProjectPage}
-      label="Show canvas timeline on async project page"
-    />
+    Show canvas timeline on async project page:
+    <button
+      on:click={() => {
+        showCanvasTimelineOnProjectPage = !showCanvasTimelineOnProjectPage;
+        CONFIG.setDevShowCanvasTimelineOnProjectPage(
+          showCanvasTimelineOnProjectPage
+        );
+      }}>{showCanvasTimelineOnProjectPage ? "shown" : "hidden"}</button
+    >
   </p>
 
   <p>


### PR DESCRIPTION
For the `showCanvasTimelineOnProjectPage` config checkbox, we were creating a writable store and syncing it to the config var. Unfortunately, because the first fetch of this value was async, we were registering our destruction handler after the component was done initializing, which would throw an error into the console. (It's not clear to me whether this actually caused a behavior issue - at most a tiny memory leak from not cleaning up these stores properly.)

Anyway, that's fixed, by using a button, which is more consistent with the other variables that can be toggled on this page anyway.