### PR TITLE
AsyncEntryEditor: recalc totals on input, not just on blur

### DIFF
--- a/src/components/ActivityEntrySlat.svelte
+++ b/src/components/ActivityEntrySlat.svelte
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2021, Design Awareness Contributors.
+  Copyright (c) 2021-2023, Design Awareness Contributors.
   SPDX-License-Identifier: BSD-3-Clause
 -->
 <script lang="ts">
@@ -56,6 +56,7 @@
     <input
       type="number"
       bind:value
+      on:input
       on:blur
       on:focus={select}
       disabled={isTotalDisabled}

--- a/src/routes/AsyncEntryEditor.svelte
+++ b/src/routes/AsyncEntryEditor.svelte
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2021, Design Awareness Contributors.
+  Copyright (c) 2021-2023, Design Awareness Contributors.
   SPDX-License-Identifier: BSD-3-Clause
 -->
 <script lang="ts">
@@ -132,6 +132,7 @@
     activity={designModel.activities[0]}
     bind:value={total}
     on:blur={update(-1)}
+    on:input={update(-1)}
     note=""
     entryMode="raw"
     isTotalRow
@@ -155,6 +156,7 @@
       bind:note={notes[i]}
       {entryMode}
       on:blur={update(i)}
+      on:input={update(i)}
     />
   {/each}
 


### PR DESCRIPTION
This change will recalculate activity time totals on input in the activity slat input fields, not just on blur.

I'd like to keep an eye on this behavior to see if it introduces unwanted behavior when clearing the field (since it will be reset to 0). I think this is probably okay, especially since users shouldn't ever be entering negative numbers, but let's test how this feels before merging this in.

This does solve the issue where the save button isn't available after entering the last percent until it's blurred, though.