### PR TITLE
ProjectDetailAsync: Don't write activity time values on input

### DIFF
--- a/src/routes/AsyncEntryEditor.svelte
+++ b/src/routes/AsyncEntryEditor.svelte
@@ -81,11 +81,7 @@
     if (i >= 0) {
       values[i] = Math.max(values[i], 0);
     }
-    if (entryMode === "raw") {
-      calculateTotal();
-    } else {
-      calculateTotalPercentage();
-    }
+    updateTotals();
     entry.data = values.map((value, i) => ({
       value:
         entryMode === "raw"
@@ -94,6 +90,15 @@
       note: notes[i],
     }));
   };
+
+  const updateTotals = () => {
+    if (entryMode === "raw") {
+      calculateTotal();
+    } else {
+      calculateTotalPercentage();
+    }
+  };
+
   const updateNote = () => {
     entry.note = entry.note.trim();
   };
@@ -156,7 +161,7 @@
       bind:note={notes[i]}
       {entryMode}
       on:blur={update(i)}
-      on:input={update(i)}
+      on:input={updateTotals}
     />
   {/each}
 


### PR DESCRIPTION
Calling the same update() function on every input event was causing Safari to clear input fields where the user had typed a decimal point. We now avoid setting the value on input, and only set it on blur. But, we can still update the total values on input, so that we can enable the save button when the total is correct.

Closes #99.